### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,7 +21,7 @@ class action_plugin_autolink2 extends DokuWiki_Action_Plugin {
   /**
    * Register its handlers with the DokuWiki's event controller
    */
-  function register(&$controller) {
+  function register(Doku_Event_Handler $controller) {
     $controller->register_hook('PARSER_WIKITEXT_PREPROCESS', 'BEFORE',  $this, '_hookautolink');
     $controller->register_hook('IO_WIKIPAGE_WRITE', 'BEFORE',  $this, '_hookautolinkwrite');
   }

--- a/syntax/add.php
+++ b/syntax/add.php
@@ -49,7 +49,7 @@ class syntax_plugin_autolink2_add extends DokuWiki_Syntax_Plugin {
      * Handle the match
      */
 
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     global $ID;
     global $conf;
     global $ACT;
@@ -64,7 +64,7 @@ class syntax_plugin_autolink2_add extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
     if ($data === false) return false;
     if (!$my = plugin_load('helper', 'autolink2')) return false;
     // XHTML output

--- a/syntax/show.php
+++ b/syntax/show.php
@@ -45,14 +45,14 @@ class syntax_plugin_autolink2_show extends DokuWiki_Syntax_Plugin {
     }
     
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
        return array($match, $state);
     }
  
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
           $renderer->doc .= $this->_renderautolink($renderer, $data[0],$data[1]);
           return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
